### PR TITLE
Port ability to get physics diagnostics

### DIFF
--- a/wrapper/shield/wrapper/__init__.py
+++ b/wrapper/shield/wrapper/__init__.py
@@ -1,5 +1,7 @@
 import pace.util
 from ._wrapper import (
+    _get_diagnostic_data,
+    _get_diagnostic_info,
     initialize,
     step,
     step_dynamics,
@@ -14,12 +16,41 @@ from ._wrapper import (
     get_tracer_metadata,
     compute_physics,
     apply_physics,
-    flags
+    flags,
+    DiagnosticInfo
 )
 from ._restart import get_restart_names, open_restart
 from . import examples
 
 from .thermodynamics import set_state_mass_conserving
+
+
+def get_diagnostic_by_name(
+    name: str, module_name: str = "gfs_phys"
+) -> pace.util.Quantity:
+    """Get a diagnostic field as a Quantity
+
+    Currently, only supports diagnostics defined in the FV3GFS_io.F90
+    """
+    info = _get_diagnostic_info()
+    for idx, meta in info.items():
+        if meta.module_name == module_name and meta.name == name:
+            return _get_diagnostic_data(idx)
+    raise ValueError(f"There is no diagnostic {name} in module {module_name}.")
+
+
+def get_diagnostic_metadata_by_name(
+    name: str, module_name: str = "gfs_phys"
+) -> DiagnosticInfo:
+    """Get diagnostic metadata by name
+
+    Currently, only supports diagnostics defined in the FV3GFS_io.F90
+    """
+    info = _get_diagnostic_info()
+    for idx, meta in info.items():
+        if meta.module_name == module_name and meta.name == name:
+            return meta
+    raise ValueError(f"There is no diagnostic {name} in module {module_name}.")
 
 
 __version__ = "0.1.0"

--- a/wrapper/templates/_wrapper.pyx
+++ b/wrapper/templates/_wrapper.pyx
@@ -17,6 +17,10 @@ MM_PER_M = 1000
 
 
 cdef extern:
+    void get_diagnostic_3d(int*, double *)
+    void get_diagnostic_2d(int*, double *)
+    void get_metadata_diagnostics(int* , int *, char*, char*, char*, char*)
+    void get_diagnostics_count(int *)
     void initialize_subroutine(int *comm)
     void do_step_subroutine()
     void cleanup_subroutine()
@@ -468,3 +472,71 @@ def save_fortran_restart():
 def cleanup():
     """Call the Fortran cleanup routines, which clear memory and write final restart files."""
     cleanup_subroutine()
+
+
+DiagnosticInfo = namedtuple(
+        'DiagnosticInfo', ['axes', 'module_name', 'name', 'description', 'unit'])
+
+
+cdef _get_diagnostic_info_by_index(int i):
+    cdef int ax
+    cdef int axes[1]
+    cdef char name[128]
+    cdef char mod_name[128]
+    cdef char desc[128]
+    cdef char unit[128]
+
+    get_metadata_diagnostics(&i, axes, &mod_name[0], &name[0], &desc[0], &unit[0])
+    ax = axes[0]
+    return DiagnosticInfo(
+        int(axes[0]),
+        str(mod_name),
+        str(name),
+        str(desc),
+        str(unit)
+    )
+
+
+def _get_diagnostic_info():
+    cdef int n
+    get_diagnostics_count(&n)
+
+    output = {}
+    for i in range(n):
+        try:
+            info = _get_diagnostic_info_by_index(i)
+        except UnicodeDecodeError:
+            # ignore errors when the names for a given array are not properly
+            # initialized, resulting non-unicode string
+            continue
+
+        if info.name:
+            output[i] = info
+    return output
+
+
+def _get_diagnostic_data(int idx):
+
+    cdef int nz
+    cdef double[:, :] buf_2d
+    cdef double[:, :, :] buf_3d
+
+    info = _get_diagnostic_info_by_index(idx)
+    ndim = info.axes
+    units = info.unit
+    shape = get_dimension_lengths()
+    dtype = np.float64
+
+    if ndim == 3:
+        array = np.empty((shape['nz'], shape['ny'], shape['nx']), dtype=dtype)
+        buf_3d = array
+        get_diagnostic_3d(&idx, &buf_3d[0, 0, 0])
+        dims = [pace.util.Z_DIM, pace.util.Y_DIM, pace.util.X_DIM]
+    elif ndim == 2:
+        array = np.empty((shape['ny'], shape['nx']), dtype=dtype)
+        buf_2d = array
+        get_diagnostic_2d(&idx, &buf_2d[0, 0])
+        dims = [pace.util.Y_DIM, pace.util.X_DIM]
+
+
+    return pace.util.Quantity(array, dims, units=units)

--- a/wrapper/templates/_wrapper.pyx
+++ b/wrapper/templates/_wrapper.pyx
@@ -475,8 +475,7 @@ def cleanup():
 
 
 DiagnosticInfo = namedtuple(
-    'DiagnosticInfo', 
-    ['axes', 'module_name', 'name', 'description', 'unit']
+    "DiagnosticInfo", ["axes", "module_name", "name", "description", "unit"]
 )
 
 

--- a/wrapper/templates/_wrapper.pyx
+++ b/wrapper/templates/_wrapper.pyx
@@ -475,21 +475,21 @@ def cleanup():
 
 
 DiagnosticInfo = namedtuple(
-        'DiagnosticInfo', ['axes', 'module_name', 'name', 'description', 'unit'])
+    'DiagnosticInfo', 
+    ['axes', 'module_name', 'name', 'description', 'unit']
+)
 
 
 cdef _get_diagnostic_info_by_index(int i):
     cdef int ax
-    cdef int axes[1]
     cdef char name[128]
     cdef char mod_name[128]
     cdef char desc[128]
     cdef char unit[128]
 
-    get_metadata_diagnostics(&i, axes, &mod_name[0], &name[0], &desc[0], &unit[0])
-    ax = axes[0]
+    get_metadata_diagnostics(&i, &ax, &mod_name[0], &name[0], &desc[0], &unit[0])
     return DiagnosticInfo(
-        int(axes[0]),
+        ax,
         str(mod_name),
         str(name),
         str(desc),

--- a/wrapper/tests/pytest/config/default.yml
+++ b/wrapper/tests/pytest/config/default.yml
@@ -389,7 +389,7 @@ namelist:
     isubc_lw: 2
     isubc_sw: 2
     ivegsrc: 1
-    ldiag3d: false
+    ldiag3d: true
     lwhtr: true
     ncld: 5
     nst_anl: true

--- a/wrapper/tests/pytest/config/restart.yml
+++ b/wrapper/tests/pytest/config/restart.yml
@@ -257,7 +257,7 @@ namelist:
     isubc_lw: 2
     isubc_sw: 2
     ivegsrc: 1
-    ldiag3d: false
+    ldiag3d: true
     lwhtr: true
     ncld: 5
     nst_anl: true

--- a/wrapper/tests/test_all_mpi_requiring.py
+++ b/wrapper/tests/test_all_mpi_requiring.py
@@ -10,6 +10,9 @@ MPI.Finalize()
 
 
 class UsingMPITests(unittest.TestCase):
+    def test_diagnostics(self):
+        run_unittest_script("test_diagnostics.py")
+
     def test_getters(self):
         run_unittest_script("test_getters.py")
 

--- a/wrapper/tests/test_diagnostics.py
+++ b/wrapper/tests/test_diagnostics.py
@@ -1,0 +1,52 @@
+import unittest
+import os
+import shield.wrapper
+import pace.util
+from mpi4py import MPI
+
+from util import get_default_config, main
+
+test_dir = os.path.dirname(os.path.abspath(__file__))
+
+
+class DiagnosticTests(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.mpi_comm = MPI.COMM_WORLD
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        self.mpi_comm.barrier()
+
+    def test_get_diag_info(self):
+        output = shield.wrapper._get_diagnostic_info()
+        assert len(output) > 0
+        for index, item in output.items():
+            self.assertIsInstance(item.axes, int)
+            self.assertIsInstance(item.module_name, str)
+
+            self.assertIsInstance(item.name, str)
+            self.assertIsNot(item.name, "")
+
+            self.assertIsInstance(item.description, str)
+            self.assertIsInstance(item.unit, str)
+
+    def test_get_diagnostic_data(self):
+        names_to_get = ["dt3dt_1", "u10m"]
+        for name in names_to_get:
+            quantity = shield.wrapper.get_diagnostic_by_name(
+                name, module_name="gfs_phys"
+            )
+            info = shield.wrapper.get_diagnostic_metadata_by_name(
+                name, module_name="gfs_phys"
+            )
+            self.assertIsInstance(quantity, pace.util.Quantity)
+            assert quantity.view[:].ndim == info.axes
+            assert quantity.units == info.unit
+
+
+if __name__ == "__main__":
+    config = get_default_config()
+    main(test_dir, config)

--- a/wrapper/tests/test_diagnostics.py
+++ b/wrapper/tests/test_diagnostics.py
@@ -50,7 +50,7 @@ class DiagnosticTests(unittest.TestCase):
             elif name == "u10m":
                 assert quantity.view[:].ndim == 2
             else:
-                raise ValueError(f"Testing only implemented for eta_shal and u10m")
+                raise ValueError("Testing only implemented for eta_shal and u10m")
 
 
 if __name__ == "__main__":

--- a/wrapper/tests/test_diagnostics.py
+++ b/wrapper/tests/test_diagnostics.py
@@ -34,7 +34,7 @@ class DiagnosticTests(unittest.TestCase):
             self.assertIsInstance(item.unit, str)
 
     def test_get_diagnostic_data(self):
-        names_to_get = ["dt3dt_1", "u10m"]
+        names_to_get = ["eta_shal", "u10m"]
         for name in names_to_get:
             quantity = shield.wrapper.get_diagnostic_by_name(
                 name, module_name="gfs_phys"
@@ -45,6 +45,12 @@ class DiagnosticTests(unittest.TestCase):
             self.assertIsInstance(quantity, pace.util.Quantity)
             assert quantity.view[:].ndim == info.axes
             assert quantity.units == info.unit
+            if name == "eta_shal":
+                assert quantity.view[:].ndim == 3
+            elif name == "u10m":
+                assert quantity.view[:].ndim == 2
+            else:
+                raise ValueError(f"Testing only implemented for eta_shal and u10m")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR ports the ability to get physics diagnostics from SHiELD from https://github.com/ai2cm/fv3gfs-wrapper/pull/161.  In SHiELD these come from `FV3GFS_io.F90` instead of `GFS_diagnostics.F90`.  This PR relies on changes recently merged in SHiELD in https://github.com/NOAA-GFDL/SHiELD_physics/pull/30; the SHiELD_physics submodule is updated accordingly.