### PR TITLE
Add dependabot configuration for tracking / updating submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      # Ensure updates are grouped into one PR in case interdependent changes
+      # are made upstream, which is not uncommon.
+      gfdl:
+        patterns:
+          - "submodules/SHiELD_SRC/*"
+          - "submodules/SHiELD_build"


### PR DESCRIPTION
This PR adds a dependabot configuration to track updates to the GFDL submodules contained in this repo.  I have tried to configure it to check for updates to all the repos once a week, and if any are updated, open a PR updating them all as a group.  The motivation behind this is that these repos are all interdependent, and so it is not uncommon for a change in one repo to require a change in another (and these updates are often made around the same time, e.g. the fortran changes required for #5).

Unfortunately I'm not sure there is a great way of testing this, so we may have to try it out and tweak things as we go.

Resolves #8