### PR TITLE
Add ability to get diagnostics manager controlled physics diagnostics

### DIFF
--- a/wrapper/lib/coupler_lib.F90
+++ b/wrapper/lib/coupler_lib.F90
@@ -646,9 +646,9 @@ module coupler_lib
           call f_to_c_string(unit, diag_type(idx)%unit)
        end subroutine
 
-       subroutine get_metadata_diagnostics(idx, diag_manager_controlled, axes, mod_name, name, desc, unit) bind(c)
-          integer(c_int), intent(in) :: idx
+       subroutine get_metadata_diagnostics(diag_manager_controlled, idx, axes, mod_name, name, desc, unit) bind(c)
           logical(c_int), intent(in) :: diag_manager_controlled
+          integer(c_int), intent(in) :: idx
           integer(c_int), intent(out) :: axes
           character(kind=c_char, len=1), dimension(128), intent(out) :: mod_name, name, desc, unit
 
@@ -700,11 +700,11 @@ module coupler_lib
           enddo
        end subroutine
 
-       subroutine get_diagnostic_3d(idx, diag_manager_controlled, out) bind(c)
+       subroutine get_diagnostic_3d(diag_manager_controlled, idx, out) bind(c)
           use dynamics_data_mod, only: i_start, i_end, j_start, j_end, nz
           use atmos_model_mod, only: Atm_block
-          integer(c_int), intent(in) :: idx
           logical(c_int), intent(in) :: diag_manager_controlled
+          integer(c_int), intent(in) :: idx
           real(c_double), intent(out), dimension(i_start():i_end(), j_start():j_end(), nz()) :: out
           ! locals
           integer :: blocks_per_MPI_domain, i, j, k, i_block, i_column, axes, n
@@ -716,10 +716,10 @@ module coupler_lib
           endif
        end subroutine
 
-       subroutine get_diagnostic_2d(idx, diag_manager_controlled, out) bind(c)
+       subroutine get_diagnostic_2d(diag_manager_controlled, idx, out) bind(c)
          use dynamics_data_mod, only: i_start, i_end, j_start, j_end, nz
-          integer(c_int), intent(in) :: idx
           logical(c_int), intent(in) :: diag_manager_controlled
+          integer(c_int), intent(in) :: idx
           real(c_double), intent(out), dimension(i_start():i_end(), j_start():j_end()) :: out
           if (diag_manager_controlled) then
              call get_diagnostic_2d_from_diag_type(Diag_diag_manager_controlled, idx, out)

--- a/wrapper/lib/coupler_lib.F90
+++ b/wrapper/lib/coupler_lib.F90
@@ -609,10 +609,10 @@ module coupler_lib
           n = size(diag_type)
        end subroutine
 
-       subroutine get_diagnostics_count(diag_manager_controlled, n) bind(c)
-          logical(c_int), intent(in) :: diag_manager_controlled
+       subroutine get_diagnostics_count(is_diag_manager_controlled, n) bind(c)
+          logical(c_int), intent(in) :: is_diag_manager_controlled
           integer(c_int), intent(out) :: n
-          if (diag_manager_controlled) then
+          if (is_diag_manager_controlled) then
              call get_diagnostics_count_from_diag_type(Diag_diag_manager_controlled, n)
            else
              call get_diagnostics_count_from_diag_type(Diag, n)
@@ -646,13 +646,13 @@ module coupler_lib
           call f_to_c_string(unit, diag_type(idx)%unit)
        end subroutine
 
-       subroutine get_metadata_diagnostics(diag_manager_controlled, idx, axes, mod_name, name, desc, unit) bind(c)
-          logical(c_int), intent(in) :: diag_manager_controlled
+       subroutine get_metadata_diagnostics(is_diag_manager_controlled, idx, axes, mod_name, name, desc, unit) bind(c)
+          logical(c_int), intent(in) :: is_diag_manager_controlled
           integer(c_int), intent(in) :: idx
           integer(c_int), intent(out) :: axes
           character(kind=c_char, len=1), dimension(128), intent(out) :: mod_name, name, desc, unit
 
-          if (diag_manager_controlled) then
+          if (is_diag_manager_controlled) then
              call get_metadata_from_diag_type(Diag_diag_manager_controlled, idx, axes, mod_name, name, desc, unit)
           else
              call get_metadata_from_diag_type(Diag, idx, axes, mod_name, name, desc, unit)
@@ -700,28 +700,28 @@ module coupler_lib
           enddo
        end subroutine
 
-       subroutine get_diagnostic_3d(diag_manager_controlled, idx, out) bind(c)
+       subroutine get_diagnostic_3d(is_diag_manager_controlled, idx, out) bind(c)
           use dynamics_data_mod, only: i_start, i_end, j_start, j_end, nz
           use atmos_model_mod, only: Atm_block
-          logical(c_int), intent(in) :: diag_manager_controlled
+          logical(c_int), intent(in) :: is_diag_manager_controlled
           integer(c_int), intent(in) :: idx
           real(c_double), intent(out), dimension(i_start():i_end(), j_start():j_end(), nz()) :: out
           ! locals
           integer :: blocks_per_MPI_domain, i, j, k, i_block, i_column, axes, n
 
-          if (diag_manager_controlled) then
+          if (is_diag_manager_controlled) then
              call get_diagnostic_3d_from_diag_type(Diag_diag_manager_controlled, idx, out)
           else
              call get_diagnostic_3d_from_diag_type(Diag, idx, out)
           endif
        end subroutine
 
-       subroutine get_diagnostic_2d(diag_manager_controlled, idx, out) bind(c)
+       subroutine get_diagnostic_2d(is_diag_manager_controlled, idx, out) bind(c)
          use dynamics_data_mod, only: i_start, i_end, j_start, j_end, nz
-          logical(c_int), intent(in) :: diag_manager_controlled
+          logical(c_int), intent(in) :: is_diag_manager_controlled
           integer(c_int), intent(in) :: idx
           real(c_double), intent(out), dimension(i_start():i_end(), j_start():j_end()) :: out
-          if (diag_manager_controlled) then
+          if (is_diag_manager_controlled) then
              call get_diagnostic_2d_from_diag_type(Diag_diag_manager_controlled, idx, out)
           else
              call get_diagnostic_2d_from_diag_type(Diag, idx, out)

--- a/wrapper/shield/wrapper/__init__.py
+++ b/wrapper/shield/wrapper/__init__.py
@@ -38,7 +38,7 @@ def get_diagnostic_by_name(
     Currently, only supports diagnostics defined in the FV3GFS_io.F90
     """
     metadata = get_diagnostic_metadata_by_name(name, module_name)
-    return _get_diagnostic_data(metadata.diag_manager_controlled, metadata.index)
+    return _get_diagnostic_data(metadata.is_diag_manager_controlled, metadata.index)
 
 
 def get_diagnostic_metadata_by_name(

--- a/wrapper/shield/wrapper/__init__.py
+++ b/wrapper/shield/wrapper/__init__.py
@@ -37,11 +37,8 @@ def get_diagnostic_by_name(
 
     Currently, only supports diagnostics defined in the FV3GFS_io.F90
     """
-    info = _get_diagnostic_info()
-    for idx, meta in info.items():
-        if meta.module_name == module_name and meta.name == name:
-            return _get_diagnostic_data(idx)
-    raise ValueError(f"There is no diagnostic {name} in module {module_name}.")
+    metadata = get_diagnostic_metadata_by_name(name, module_name)
+    return _get_diagnostic_data(metadata.index, metadata.diag_manager_controlled)
 
 
 def get_diagnostic_metadata_by_name(
@@ -52,10 +49,12 @@ def get_diagnostic_metadata_by_name(
     Currently, only supports diagnostics defined in the FV3GFS_io.F90
     """
     info = _get_diagnostic_info()
-    for idx, meta in info.items():
-        if meta.module_name == module_name and meta.name == name:
-            return meta
-    raise ValueError(f"There is no diagnostic {name} in module {module_name}.")
+
+    key = module_name, name
+    if key in info:
+        return info[key]
+    else:
+        raise ValueError(f"There is no diagnostic {name} in module {module_name}.")
 
 
 __version__ = "0.1.0"

--- a/wrapper/shield/wrapper/__init__.py
+++ b/wrapper/shield/wrapper/__init__.py
@@ -38,7 +38,7 @@ def get_diagnostic_by_name(
     Currently, only supports diagnostics defined in the FV3GFS_io.F90
     """
     metadata = get_diagnostic_metadata_by_name(name, module_name)
-    return _get_diagnostic_data(metadata.index, metadata.diag_manager_controlled)
+    return _get_diagnostic_data(metadata.diag_manager_controlled, metadata.index)
 
 
 def get_diagnostic_metadata_by_name(

--- a/wrapper/templates/_wrapper.pyx
+++ b/wrapper/templates/_wrapper.pyx
@@ -17,10 +17,10 @@ MM_PER_M = 1000
 
 
 cdef extern:
-    void get_diagnostic_3d(int*, double *)
-    void get_diagnostic_2d(int*, double *)
-    void get_metadata_diagnostics(int* , int *, char*, char*, char*, char*)
-    void get_diagnostics_count(int *)
+    void get_diagnostic_3d(int*, bint*, double *)
+    void get_diagnostic_2d(int*, bint*, double *)
+    void get_metadata_diagnostics(int* , bint*, int *, char*, char*, char*, char*)
+    void get_diagnostics_count(bint*, int *)
     void initialize_subroutine(int *comm)
     void do_step_subroutine()
     void cleanup_subroutine()
@@ -495,19 +495,21 @@ def cleanup():
 
 
 DiagnosticInfo = namedtuple(
-    "DiagnosticInfo", ["axes", "module_name", "name", "description", "unit"]
+    "DiagnosticInfo", ["index", "diag_manager_controlled", "axes", "module_name", "name", "description", "unit"]
 )
 
 
-cdef _get_diagnostic_info_by_index(int i):
+cdef _get_diagnostic_info_by_index(int i, bint diag_manager_controlled):
     cdef int ax
     cdef char name[128]
     cdef char mod_name[128]
     cdef char desc[128]
     cdef char unit[128]
 
-    get_metadata_diagnostics(&i, &ax, &mod_name[0], &name[0], &desc[0], &unit[0])
+    get_metadata_diagnostics(&i, &diag_manager_controlled, &ax, &mod_name[0], &name[0], &desc[0], &unit[0])
     return DiagnosticInfo(
+        i,
+        diag_manager_controlled,
         ax,
         str(mod_name),
         str(name),
@@ -516,31 +518,38 @@ cdef _get_diagnostic_info_by_index(int i):
     )
 
 
-def _get_diagnostic_info():
+def _get_diagnostic_info_by_type(bint diag_manager_controlled=False):
     cdef int n
-    get_diagnostics_count(&n)
+    get_diagnostics_count(&diag_manager_controlled, &n)
 
     output = {}
     for i in range(n):
         try:
-            info = _get_diagnostic_info_by_index(i)
+            info = _get_diagnostic_info_by_index(i, diag_manager_controlled)
         except UnicodeDecodeError:
             # ignore errors when the names for a given array are not properly
             # initialized, resulting non-unicode string
             continue
 
         if info.name:
-            output[i] = info
+            output[info.module_name, info.name] = info
+
     return output
 
 
-def _get_diagnostic_data(int idx):
+def _get_diagnostic_info():
+    not_diag_manager_controlled = _get_diagnostic_info_by_type(diag_manager_controlled=False)
+    diag_manager_controlled = _get_diagnostic_info_by_type(diag_manager_controlled=True)
+    return {**not_diag_manager_controlled, **diag_manager_controlled}
+
+
+def _get_diagnostic_data(int idx, bint diag_manager_controlled):
 
     cdef int nz
     cdef double[:, :] buf_2d
     cdef double[:, :, :] buf_3d
 
-    info = _get_diagnostic_info_by_index(idx)
+    info = _get_diagnostic_info_by_index(idx, diag_manager_controlled)
     ndim = info.axes
     units = info.unit
     shape = get_dimension_lengths()
@@ -549,12 +558,12 @@ def _get_diagnostic_data(int idx):
     if ndim == 3:
         array = np.empty((shape['nz'], shape['ny'], shape['nx']), dtype=dtype)
         buf_3d = array
-        get_diagnostic_3d(&idx, &buf_3d[0, 0, 0])
+        get_diagnostic_3d(&idx, &diag_manager_controlled, &buf_3d[0, 0, 0])
         dims = [pace.util.Z_DIM, pace.util.Y_DIM, pace.util.X_DIM]
     elif ndim == 2:
         array = np.empty((shape['ny'], shape['nx']), dtype=dtype)
         buf_2d = array
-        get_diagnostic_2d(&idx, &buf_2d[0, 0])
+        get_diagnostic_2d(&idx, &diag_manager_controlled, &buf_2d[0, 0])
         dims = [pace.util.Y_DIM, pace.util.X_DIM]
 
 

--- a/wrapper/templates/_wrapper.pyx
+++ b/wrapper/templates/_wrapper.pyx
@@ -495,7 +495,16 @@ def cleanup():
 
 
 DiagnosticInfo = namedtuple(
-    "DiagnosticInfo", ["index", "diag_manager_controlled", "axes", "module_name", "name", "description", "unit"]
+    "DiagnosticInfo",
+    [
+        "index",
+        "diag_manager_controlled",
+        "axes",
+        "module_name",
+        "name",
+        "description",
+        "unit"
+    ]
 )
 
 
@@ -506,7 +515,15 @@ cdef _get_diagnostic_info_by_index(int i, bint diag_manager_controlled):
     cdef char desc[128]
     cdef char unit[128]
 
-    get_metadata_diagnostics(&i, &diag_manager_controlled, &ax, &mod_name[0], &name[0], &desc[0], &unit[0])
+    get_metadata_diagnostics(
+        &i,
+        &diag_manager_controlled,
+        &ax,
+        &mod_name[0],
+        &name[0],
+        &desc[0],
+        &unit[0]
+    )
     return DiagnosticInfo(
         i,
         diag_manager_controlled,
@@ -538,8 +555,12 @@ def _get_diagnostic_info_by_type(bint diag_manager_controlled=False):
 
 
 def _get_diagnostic_info():
-    not_diag_manager_controlled = _get_diagnostic_info_by_type(diag_manager_controlled=False)
-    diag_manager_controlled = _get_diagnostic_info_by_type(diag_manager_controlled=True)
+    not_diag_manager_controlled = _get_diagnostic_info_by_type(
+        diag_manager_controlled=False
+    )
+    diag_manager_controlled = _get_diagnostic_info_by_type(
+        diag_manager_controlled=True
+    )
     return {**not_diag_manager_controlled, **diag_manager_controlled}
 
 

--- a/wrapper/tests/test_diagnostics.py
+++ b/wrapper/tests/test_diagnostics.py
@@ -23,7 +23,7 @@ class DiagnosticTests(unittest.TestCase):
     def test_get_diag_info(self):
         output = shield.wrapper._get_diagnostic_info()
         assert len(output) > 0
-        for index, item in output.items():
+        for key, item in output.items():
             self.assertIsInstance(item.axes, int)
             self.assertIsInstance(item.module_name, str)
 
@@ -34,7 +34,7 @@ class DiagnosticTests(unittest.TestCase):
             self.assertIsInstance(item.unit, str)
 
     def test_get_diagnostic_data(self):
-        names_to_get = ["eta_shal", "u10m"]
+        names_to_get = ["eta_shal", "u10m", "tendency_of_specific_humidity_due_to_microphysics"]
         for name in names_to_get:
             quantity = shield.wrapper.get_diagnostic_by_name(
                 name, module_name="gfs_phys"
@@ -45,12 +45,12 @@ class DiagnosticTests(unittest.TestCase):
             self.assertIsInstance(quantity, pace.util.Quantity)
             assert quantity.view[:].ndim == info.axes
             assert quantity.units == info.unit
-            if name == "eta_shal":
+            if name == "eta_shal" or name == "tendency_of_specific_humidity_due_to_microphysics":
                 assert quantity.view[:].ndim == 3
             elif name == "u10m":
                 assert quantity.view[:].ndim == 2
             else:
-                raise ValueError("Testing only implemented for eta_shal and u10m")
+                raise ValueError(f"Testing only implemented for {names_to_get}.")
 
 
 if __name__ == "__main__":

--- a/wrapper/tests/test_diagnostics.py
+++ b/wrapper/tests/test_diagnostics.py
@@ -23,7 +23,7 @@ class DiagnosticTests(unittest.TestCase):
     def test_get_diag_info(self):
         output = shield.wrapper._get_diagnostic_info()
         assert len(output) > 0
-        for key, item in output.items():
+        for item in output.values():
             self.assertIsInstance(item.axes, int)
             self.assertIsInstance(item.module_name, str)
 
@@ -50,7 +50,7 @@ class DiagnosticTests(unittest.TestCase):
             elif name == "u10m":
                 assert quantity.view[:].ndim == 2
             else:
-                raise ValueError(f"Testing only implemented for {names_to_get}.")
+                raise ValueError(f"Testing not implemented for getting {name!r}.")
 
 
 if __name__ == "__main__":

--- a/wrapper/tests/test_diagnostics.py
+++ b/wrapper/tests/test_diagnostics.py
@@ -24,6 +24,9 @@ class DiagnosticTests(unittest.TestCase):
         output = shield.wrapper._get_diagnostic_info()
         assert len(output) > 0
         for item in output.values():
+            self.assertIsInstance(item.is_diag_manager_controlled, bool)
+            self.assertIsInstance(item.index, int)
+
             self.assertIsInstance(item.axes, int)
             self.assertIsInstance(item.module_name, str)
 


### PR DESCRIPTION
In FV3GFS, I included the diagnostics manager controlled physics diagnostics within the same data structure as the non-diagnostics-manager controlled physics diagnostics, while in SHiELD, I created a separate data structure for clarity.  To enable getting diagnostics manager controlled diagnostics in the SHiELD-wrapper, some backend modifications are needed to work around this split.  The frontend API remains identical, however.

In the fv3net prognostic run, [we happen to always get a diagnostics manager controlled diagnostic within the time loop](https://github.com/ai2cm/fv3net/blob/92c808d13748f165d9fdaa8c0c7714f82f024eea/workflows/prognostic_c48_run/runtime/loop.py#L413-L415).  This is not strictly necessary—we *could* introduce model specific logic in the time loop to work around this, as we did in ai2cm/fv3net#2350—but since this diagnostic does exist in SHiELD, we might as well enable getting it so that the fv3net prognostic run time loop (and testing logic) can remain as clean as possible.

Note that this does require a minor upstream change in the SHiELD_physics repository to make some additional objects public: https://github.com/NOAA-GFDL/SHiELD_physics/pull/33, which has now been merged.

### Backend changes

- Subroutines `get_metadata_diagnostics`, `get_diagnostic_2d`, and `get_diagnostic_3d` within `coupler_lib.F90` now take an additional boolean argument denoting whether one would like to get data from a `diag_manager_controlled` diagnostic or not.
- The dictionary returned by `_get_diagnostic_info` now uses tuple-valued keys `(module_name, name)` instead of integer keys, since the index no longer uniquely defines a diagnostic.  `diag_manager_controlled` and `index` are now added as attributes to the `DiagnosticInfo` named tuple.  Not only is this more general than what was implemented previously, it also makes for simpler querying of whether the requested diagnostic exists within `get_diagnostic_metadata_by_name`.